### PR TITLE
Fix use-after-free

### DIFF
--- a/ps2-decompile/detach.c
+++ b/ps2-decompile/detach.c
@@ -17,11 +17,11 @@ int usbmouse_detach(int devId) {
     if (p->port > 0)
         memset(&dword_2D18[2 * p->port], 0, 8u);
 
-    unit_free(p);
-
 #ifdef DEBUG
     (void) printf("usbmouse%d: detached : port %d\n", p->port1, p->port);
 #endif
+    
+    unit_free(p);
 
     return 0;
 }

--- a/ps2-decompile/detach.c
+++ b/ps2-decompile/detach.c
@@ -22,6 +22,6 @@ int usbmouse_detach(int devId) {
 #endif
     
     unit_free(p);
-
+    p = NULL;
     return 0;
 }


### PR DESCRIPTION
Apparently during the refactor i used the shared_t after unit_free. correct this.