### PR TITLE
Security: Get rid of dangling pointer in attach.c

### DIFF
--- a/ps2-decompile/attach.c
+++ b/ps2-decompile/attach.c
@@ -171,8 +171,10 @@ int usbmouse_attach(int devId) {
     return 0;
 
 fail:
-    if (g)
+    if (g) {
         unit_free(g);
+        g = NULL;
+    }
 
     return -1;
 }


### PR DESCRIPTION
If something fails and a jmp triggers to `fail` g is left dangling.